### PR TITLE
Added a standalone installer for RAR-files.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,14 @@
         </repository>
     </repositories>
 
-	<dependencies>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <dependencies>
 	<!-- http://mvnrepository.com/artifact/com.github.junrar/junrar -->
 	<dependency>
 	    <groupId>com.github.junrar</groupId>
@@ -33,14 +40,18 @@
 	    <version>0.7</version>
 	</dependency>
 
-	</dependencies>
+	<dependency>
+	    <groupId>org.jenkins-ci.main</groupId>
+	    <artifactId>jenkins-core</artifactId>
+	    <version>1.647</version>
+	</dependency>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
+	<dependency>
+   	    <groupId>org.jenkins-ci.main</groupId>
+   	    <artifactId>remoting</artifactId>
+   	    <version>2.53.2</version>
+	</dependency>
+    </dependencies>
 
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.synopsys.arc.jenkinsci</groupId>
     <artifactId>extra-tool-installers</artifactId>
-    <version>0.4-SNAPSHOT</version>
+    <version>0.3</version>
     <name>Jenkins Extra Tool Installers Plugin</name>
     <description>Provides additional tool installers</description>
     <packaging>hpi</packaging>
@@ -24,6 +24,16 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
+
+	<dependencies>
+	<!-- http://mvnrepository.com/artifact/com.github.junrar/junrar -->
+	<dependency>
+	    <groupId>com.github.junrar</groupId>
+	    <artifactId>junrar</artifactId>
+	    <version>0.7</version>
+	</dependency>
+
+	</dependencies>
 
     <pluginRepositories>
         <pluginRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -35,17 +35,11 @@
     </pluginRepositories>
 
     <dependencies>
-<!-- .................... Working .................... -->
-
-
-<!-- http://mvnrepository.com/artifact/com.github.beothorn/junrar -->
 	<dependency>
 	    <groupId>com.github.junrar</groupId>
 	    <artifactId>junrar</artifactId>
 	    <version>0.7</version>
 	</dependency>
-
-
 
 	<dependency>
             <groupId>org.jenkins-ci.main</groupId>
@@ -71,8 +65,6 @@
 	    <version>1.6</version>
 	</dependency>
 
-<!-- .................... Errors .................... -->
-
 	<dependency>
 	    <groupId>org.jenkins-ci.main</groupId>
 	    <artifactId>jenkins-core</artifactId>
@@ -84,17 +76,6 @@
 	    <artifactId>hudson-core</artifactId>
 	    <version>3.3.3</version>
 	</dependency>
-
-<!-- http://mvnrepository.com/artifact/org.jvnet.hudson.main/maven3-model -->
-<dependency>
-    <groupId>org.jvnet.hudson.main</groupId>
-    <artifactId>maven3-model</artifactId>
-    <version>2.2.0</version>
-</dependency>
-
-
-
-<!-- ................................................ -->
     </dependencies>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.480.3</version>
+	<version>1.480.3</version>
+<!--    <version>2.2</version>		-->
     </parent>
 
     <groupId>com.synopsys.arc.jenkinsci</groupId>
@@ -16,6 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	<jenkins.version>1.609.1</jenkins.version>
     </properties>
 
     <repositories>
@@ -33,12 +35,43 @@
     </pluginRepositories>
 
     <dependencies>
-	<!-- http://mvnrepository.com/artifact/com.github.junrar/junrar -->
+<!-- .................... Working .................... -->
+
+
+<!-- http://mvnrepository.com/artifact/com.github.beothorn/junrar -->
 	<dependency>
 	    <groupId>com.github.junrar</groupId>
 	    <artifactId>junrar</artifactId>
 	    <version>0.7</version>
 	</dependency>
+
+
+
+	<dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>remoting</artifactId>
+            <version>2.59</version>
+	</dependency>
+
+	<dependency>
+	    <groupId>org.eclipse.hudson</groupId>
+	    <artifactId>hudson-cli</artifactId>
+	    <version>3.2.1</version>
+	</dependency>
+
+	<dependency>
+	    <groupId>org.eclipse.hudson</groupId>
+	    <artifactId>hudson-remoting</artifactId>
+	    <version>3.0.3</version>
+	</dependency>
+
+	<dependency>
+	    <groupId>org.jenkins-ci.plugins</groupId>
+	    <artifactId>matrix-project</artifactId>
+	    <version>1.6</version>
+	</dependency>
+
+<!-- .................... Errors .................... -->
 
 	<dependency>
 	    <groupId>org.jenkins-ci.main</groupId>
@@ -47,10 +80,21 @@
 	</dependency>
 
 	<dependency>
-   	    <groupId>org.jenkins-ci.main</groupId>
-   	    <artifactId>remoting</artifactId>
-   	    <version>2.53.2</version>
+	    <groupId>org.eclipse.hudson</groupId>
+	    <artifactId>hudson-core</artifactId>
+	    <version>3.3.3</version>
 	</dependency>
+
+<!-- http://mvnrepository.com/artifact/org.jvnet.hudson.main/maven3-model -->
+<dependency>
+    <groupId>org.jvnet.hudson.main</groupId>
+    <artifactId>maven3-model</artifactId>
+    <version>2.2.0</version>
+</dependency>
+
+
+
+<!-- ................................................ -->
     </dependencies>
 
     <developers>

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/extratoolinstallers/installers/RarExtractionInstaller.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/extratoolinstallers/installers/RarExtractionInstaller.java
@@ -1,0 +1,352 @@
+package com.synopsys.arc.jenkinsci.plugins.extratoolinstallers.installers;
+
+
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.ProxyConfiguration;
+import hudson.model.TaskListener;
+import hudson.model.Node;
+import hudson.tools.ToolInstallation;
+import hudson.tools.ToolInstallerDescriptor;
+import hudson.util.FormValidation;
+import hudson.util.IOUtils;
+
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.github.junrar.Archive;
+import com.github.junrar.exception.RarException;
+import com.github.junrar.rarfile.FileHeader;
+
+import org.apache.commons.io.input.CountingInputStream;
+
+import org.kohsuke.stapler.QueryParameter;
+
+public class RarExtractionInstaller extends AbstractExtraToolInstaller {
+
+	/*
+	 * URL of a RAR file which should be downloaded in case the tool is missing.
+	 */
+	private final String toolHome;
+
+	private static final int MAX_REDIRECTS = 20;
+	
+	public static final String RAR_EXTRACTION_INSTALLER_BAD_CONNECTION = "Server rejected connection.";
+	public static final String RAR_EXTRACTION_INSTALLER_COULD_NOT_CONNECT = "Could not connect to URL.";
+	public static final String RAR_EXTRACTION_INSTALLER_DISPLAY_NAME = "Extract *.rar";
+	public static final String RAR_EXTRACTION_INSTALLER_MALFORMED_URL = "Malformed URL.";
+
+	public RarExtractionInstaller(String label, String toolHome,
+			boolean failOnSubstitution) {
+		super(label, toolHome, failOnSubstitution);
+		this.toolHome = toolHome;
+	}
+
+	public String getUrl() {
+		return toolHome;
+	}
+
+	@Override
+	public FilePath performInstallation(ToolInstallation tool, Node node,
+			TaskListener log) throws IOException, InterruptedException {
+
+		FilePath dir = preferredLocation(tool, node);
+		if (installIfNecessaryFrom(
+				dir,
+				new URL(super.getToolHome()),
+				log,
+				"Unpacking " + toolHome + " to " + dir + " on "
+						+ node.getDisplayName(), MAX_REDIRECTS)) {
+			log.getLogger().println("RAR extraction successful.");
+		}
+		// Inget subdir om det inte behövs.
+		return dir;
+	}
+
+	private boolean installIfNecessaryFrom(FilePath dir, @Nonnull URL archive,
+			@CheckForNull TaskListener listener, @Nonnull String message,
+			int maxRedir) throws IOException, InterruptedException {
+		try {
+			FilePath timestamp = dir.child(".timestamp");
+			long lastModified = timestamp.lastModified();
+			URLConnection con = null;
+			try {
+				con = ProxyConfiguration.open(archive);
+				if (lastModified != 0) {
+					con.setIfModifiedSince(lastModified);
+				}
+				con.connect();
+			} catch (IOException x) {
+				if (dir.exists()) {
+					// Cannot connect now, so assume whatever was last unpacked
+					// is still OK.
+					if (listener != null) {
+						listener.getLogger().println(
+								"Skipping installation of " + archive + " to "
+										+ archive + ": " + x);
+						return false;
+					}
+				} else {
+					throw x;
+				}
+			}
+
+			if (lastModified != 0 && con instanceof HttpURLConnection) {
+				HttpURLConnection httpCon = (HttpURLConnection) con;
+				int responseCode = httpCon.getResponseCode();
+				if (responseCode == HttpURLConnection.HTTP_NOT_MODIFIED) {
+					return false;
+
+				} else if (responseCode != HttpURLConnection.HTTP_OK) {
+					listener.getLogger().println(
+							"Skipping installation of " + archive + " to "
+									+ archive + " due to server error: "
+									+ responseCode + " "
+									+ httpCon.getResponseMessage());
+					return false;
+				}
+			}
+
+			long sourceTimestamp = con.getLastModified();
+
+			if (dir.exists()) {
+				if (lastModified != 0 && sourceTimestamp == lastModified)
+					return false; // already up to date
+				// Fungerar deras metoder i mitt fall?
+				dir.deleteContents();
+			} else {
+				// Fungerar deras metoder i mitt fall?
+				dir.mkdirs();
+			}
+			if (listener != null) {
+				listener.getLogger().println(message);
+			}
+
+			// FELKÄLLA eventuellt.
+			// Fungerar deras metoder i mitt fall?
+			// if (dir.isRemote()) {
+			// // First try to download from the slave machine.
+			// try {
+			// // Ska detta göras?
+			// dir.act(new Unpack(archive));
+			// timestamp.touch(sourceTimestamp);
+			// return true;
+			// } catch (IOException x) {
+			// if (listener != null) {
+			// x.printStackTrace(listener.error("Failed to download " + archive
+			// + " from slave; will retry from master"));
+			// }
+			// }
+			// }
+
+			// for HTTP downloads, enable automatic retry for added resilience
+			InputStream in;
+			if (archive.getProtocol().startsWith("http")) {
+				// in = ProxyConfiguration.getInputStream(archive);
+				in = con.getInputStream();
+			} else {
+				in = con.getInputStream();
+			}
+			CountingInputStream cis = new CountingInputStream(in);
+			unrarFrom(cis);
+			// try{
+			// // Packa upp här (med CountingIS?)
+			//
+			// }catch(IOException e){
+			// throw new
+			// IOException(String.format("Failed to unpack %s (%d bytes read of total %d)",
+			// archive,cis.getByteCount(),con.getContentLength()),e);
+			// }
+			timestamp.touch(sourceTimestamp);
+			return true;
+
+		} catch (IOException e) {
+			throw new IOException("Failed to install " + archive + " to "
+					+ archive, e);
+		}
+	}
+
+	private void unrarFrom(InputStream _in) {
+		final InputStream in = new CountingInputStream(_in);
+		try{
+			unrar(new File(toolHome), in);
+		}catch(IOException e){
+//			throw new IOException("Failed installation - IOException in unrarFrom(...)", e);
+		}
+	}
+
+	private void unrar(File dir, InputStream in) throws IOException {
+		File tmpFile = File.createTempFile("tmpzip", null); // uses
+															// java.io.tmpdir
+		try {
+			// TODO why does this not simply use ZipInputStream?
+			IOUtils.copy(in, tmpFile);
+			unrar(dir, tmpFile);
+		} finally {
+			tmpFile.delete();
+		}
+	}
+
+	private void unrar(File archive, File tmpFile) {
+		Archive arch = null;
+		try {
+			arch = new Archive(archive);
+			if (arch != null) {
+				if (arch.isEncrypted()) {
+					System.out.println("Archive encrypted. Aborting.");
+					return;
+				}
+				FileHeader fh = null;
+				while (true) {
+					fh = arch.nextFileHeader();
+					if (fh == null) {
+						break;
+					}
+					if (fh.isEncrypted()) {
+						System.out.println("File encrypted: "
+								+ fh.getFileNameString());
+						continue;
+					}
+
+					System.out.println("Extracting: " + fh.getFileNameString());
+					if (fh.isDirectory()) {
+//						 createDirectory(fh, destination);
+//						mkdirs(new File(fh.getFileNameString()));
+					} else {
+//						 File f = createFile(fh, destination);
+//						OutputStream stream = new FileOutputStream(f);
+//						arch.extractFile(fh, stream);
+//						stream.close();
+					}
+				}
+			}
+		} catch (IOException e) {
+			// Handle exception
+		} catch (RarException e) {
+			// Handle exception
+		}
+	}
+
+//	private boolean mkdirs(File dir) {
+//		if (dir.exists())
+//			return false;
+//
+//		filterNonNull().mkdirs(dir);
+//		return dir.mkdirs();
+//	}
+
+//	private @Nonnull
+//	SoloFilePathFilter filterNonNull() {
+//		return filter != null ? filter : UNRESTRICTED;
+//	}
+
+	@Extension
+	public static class DescriptorImpl extends
+			ToolInstallerDescriptor<RarExtractionInstaller> {
+
+		public String getDisplayName() {
+			return RAR_EXTRACTION_INSTALLER_DISPLAY_NAME;
+		}
+
+		public FormValidation doCheckUrl(@QueryParameter String value) {
+			try {
+				URLConnection conn = ProxyConfiguration.open(new URL(value));
+				conn.connect();
+				if (conn instanceof HttpURLConnection) {
+					if (((HttpURLConnection) conn).getResponseCode() != HttpURLConnection.HTTP_OK) {
+						return FormValidation.error(RAR_EXTRACTION_INSTALLER_COULD_NOT_CONNECT);
+					}
+				}
+				return FormValidation.ok();
+			} catch (MalformedURLException x) {
+				return FormValidation.error(RAR_EXTRACTION_INSTALLER_MALFORMED_URL);
+			} catch (IOException x) {
+				return FormValidation.error(x,
+						RAR_EXTRACTION_INSTALLER_COULD_NOT_CONNECT);
+			}
+		}
+
+	}
+	
+}
+
+	// private static String normalize(String path){
+	// // Eventuellt behövs en private metod som "normaliserar"
+	// }
+
+	// private boolean mkdirs(File dir) {
+	// if (dir.exists()) return false;
+	//
+	// filterNonNull().mkdirs(dir);
+	// return dir.mkdirs();
+	// }
+	//
+	//
+	
+	
+	
+	
+	
+	
+	// -----------------------------------------------------------------------------------------------
+	// // --------- Sub-methods for installIfNecessary
+	// --------------------------------------------------
+	// //
+	// -----------------------------------------------------------------------------------------------
+	//
+	// public boolean exists() throws IOException, InterruptedException {
+	// return act(new SecureFileCallable<Boolean>() {
+	// private static final long serialVersionUID = 1L;
+	// public Boolean invoke(File f, VirtualChannel channel) throws IOException
+	// {
+	// return stating(f).exists();
+	// }
+	// });
+	// }
+	//
+	// public <T> T act(final FileCallable<T> callable) throws IOException,
+	// InterruptedException {
+	// return act(callable,callable.getClass().getClassLoader());
+	// }
+	//
+	// private <T> T act(final FileCallable<T> callable, ClassLoader cl) throws
+	// IOException, InterruptedException {
+	// if(channel!=null) {
+	// // run this on a remote system
+	// try {
+	// DelegatingCallable<T,IOException> wrapper = new
+	// FileCallableWrapper<T>(callable, cl);
+	// for (FileCallableWrapperFactory factory :
+	// ExtensionList.lookup(FileCallableWrapperFactory.class)) {
+	// wrapper = factory.wrap(wrapper);
+	// }
+	// return channel.call(wrapper);
+	// } catch (TunneledInterruptedException e) {
+	// throw (InterruptedException)new
+	// InterruptedException(e.getMessage()).initCause(e);
+	// } catch (AbortException e) {
+	// throw e; // pass through so that the caller can catch it as
+	// AbortException
+	// } catch (IOException e) {
+	// // wrap it into a new IOException so that we get the caller's stack trace
+	// as well.
+	// throw new IOException("remote file operation failed: " + remote + " at "
+	// + channel + ": " + e, e);
+	// }
+	// } else {
+	// // the file is on the local machine.
+	// return callable.invoke(new File(remote), localChannel);
+	// }
+	// }
+	//
+	// 

--- a/src/main/java/com/synopsys/arc/jenkinsci/plugins/extratoolinstallers/installers/RarExtractionInstaller.java
+++ b/src/main/java/com/synopsys/arc/jenkinsci/plugins/extratoolinstallers/installers/RarExtractionInstaller.java
@@ -1,10 +1,7 @@
 package com.synopsys.arc.jenkinsci.plugins.extratoolinstallers.installers;
 
-
-
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-
 
 import hudson.Extension;
 import hudson.FilePath;
@@ -40,7 +37,7 @@ public class RarExtractionInstaller extends AbstractExtraToolInstaller {
 	private final String toolHome;
 
 	private static final int MAX_REDIRECTS = 20;
-	
+
 	public static final String RAR_EXTRACTION_INSTALLER_BAD_CONNECTION = "Server rejected connection.";
 	public static final String RAR_EXTRACTION_INSTALLER_COULD_NOT_CONNECT = "Could not connect to URL.";
 	public static final String RAR_EXTRACTION_INSTALLER_DISPLAY_NAME = "Extract *.rar";
@@ -159,14 +156,14 @@ public class RarExtractionInstaller extends AbstractExtraToolInstaller {
 			}
 			CountingInputStream cis = new CountingInputStream(in);
 			unrarFrom(cis);
-			// try{
-			// // Packa upp här (med CountingIS?)
-			//
-			// }catch(IOException e){
-			// throw new
-			// IOException(String.format("Failed to unpack %s (%d bytes read of total %d)",
-			// archive,cis.getByteCount(),con.getContentLength()),e);
-			// }
+//			try {
+//				// Packa upp här (med CountingIS?)
+//
+//			} catch (IOException e) {
+//				throw new IOException(String.format(
+//						"Failed to unpack %s (%d bytes read of total %d)",
+//						archive, cis.getByteCount(), con.getContentLength()), e);
+//			}
 			timestamp.touch(sourceTimestamp);
 			return true;
 
@@ -178,18 +175,19 @@ public class RarExtractionInstaller extends AbstractExtraToolInstaller {
 
 	private void unrarFrom(InputStream _in) {
 		final InputStream in = new CountingInputStream(_in);
-		try{
+		try {
 			unrar(new File(toolHome), in);
-		}catch(IOException e){
-//			throw new IOException("Failed installation - IOException in unrarFrom(...)", e);
+		} catch (IOException e) {
+			// throw new
+			// IOException("Failed installation - IOException in unrarFrom(...)",
+			// e);
 		}
 	}
 
 	private void unrar(File dir, InputStream in) throws IOException {
-		File tmpFile = File.createTempFile("tmpzip", null); // uses
-															// java.io.tmpdir
+		File tmpFile = File.createTempFile("tmpzip", null);
+
 		try {
-			// TODO why does this not simply use ZipInputStream?
 			IOUtils.copy(in, tmpFile);
 			unrar(dir, tmpFile);
 		} finally {
@@ -220,13 +218,13 @@ public class RarExtractionInstaller extends AbstractExtraToolInstaller {
 
 					System.out.println("Extracting: " + fh.getFileNameString());
 					if (fh.isDirectory()) {
-//						 createDirectory(fh, destination);
-//						mkdirs(new File(fh.getFileNameString()));
+						// createDirectory(fh, destination);
+						// mkdirs(new File(fh.getFileNameString()));
 					} else {
-//						 File f = createFile(fh, destination);
-//						OutputStream stream = new FileOutputStream(f);
-//						arch.extractFile(fh, stream);
-//						stream.close();
+						// File f = createFile(fh, destination);
+						// OutputStream stream = new FileOutputStream(f);
+						// arch.extractFile(fh, stream);
+						// stream.close();
 					}
 				}
 			}
@@ -237,18 +235,18 @@ public class RarExtractionInstaller extends AbstractExtraToolInstaller {
 		}
 	}
 
-//	private boolean mkdirs(File dir) {
-//		if (dir.exists())
-//			return false;
-//
-//		filterNonNull().mkdirs(dir);
-//		return dir.mkdirs();
-//	}
+	// private boolean mkdirs(File dir) {
+	// if (dir.exists())
+	// return false;
+	//
+	// filterNonNull().mkdirs(dir);
+	// return dir.mkdirs();
+	// }
 
-//	private @Nonnull
-//	SoloFilePathFilter filterNonNull() {
-//		return filter != null ? filter : UNRESTRICTED;
-//	}
+	// private @Nonnull
+	// SoloFilePathFilter filterNonNull() {
+	// return filter != null ? filter : UNRESTRICTED;
+	// }
 
 	@Extension
 	public static class DescriptorImpl extends
@@ -264,12 +262,14 @@ public class RarExtractionInstaller extends AbstractExtraToolInstaller {
 				conn.connect();
 				if (conn instanceof HttpURLConnection) {
 					if (((HttpURLConnection) conn).getResponseCode() != HttpURLConnection.HTTP_OK) {
-						return FormValidation.error(RAR_EXTRACTION_INSTALLER_COULD_NOT_CONNECT);
+						return FormValidation
+								.error(RAR_EXTRACTION_INSTALLER_COULD_NOT_CONNECT);
 					}
 				}
 				return FormValidation.ok();
 			} catch (MalformedURLException x) {
-				return FormValidation.error(RAR_EXTRACTION_INSTALLER_MALFORMED_URL);
+				return FormValidation
+						.error(RAR_EXTRACTION_INSTALLER_MALFORMED_URL);
 			} catch (IOException x) {
 				return FormValidation.error(x,
 						RAR_EXTRACTION_INSTALLER_COULD_NOT_CONNECT);
@@ -277,76 +277,17 @@ public class RarExtractionInstaller extends AbstractExtraToolInstaller {
 		}
 
 	}
-	
-}
 
 	// private static String normalize(String path){
-	// // Eventuellt behövs en private metod som "normaliserar"
+	// // Might need a method to normalize the path where the tool will be
+	// installed.
 	// }
 
+	//
 	// private boolean mkdirs(File dir) {
 	// if (dir.exists()) return false;
 	//
 	// filterNonNull().mkdirs(dir);
 	// return dir.mkdirs();
 	// }
-	//
-	//
-	
-	
-	
-	
-	
-	
-	// -----------------------------------------------------------------------------------------------
-	// // --------- Sub-methods for installIfNecessary
-	// --------------------------------------------------
-	// //
-	// -----------------------------------------------------------------------------------------------
-	//
-	// public boolean exists() throws IOException, InterruptedException {
-	// return act(new SecureFileCallable<Boolean>() {
-	// private static final long serialVersionUID = 1L;
-	// public Boolean invoke(File f, VirtualChannel channel) throws IOException
-	// {
-	// return stating(f).exists();
-	// }
-	// });
-	// }
-	//
-	// public <T> T act(final FileCallable<T> callable) throws IOException,
-	// InterruptedException {
-	// return act(callable,callable.getClass().getClassLoader());
-	// }
-	//
-	// private <T> T act(final FileCallable<T> callable, ClassLoader cl) throws
-	// IOException, InterruptedException {
-	// if(channel!=null) {
-	// // run this on a remote system
-	// try {
-	// DelegatingCallable<T,IOException> wrapper = new
-	// FileCallableWrapper<T>(callable, cl);
-	// for (FileCallableWrapperFactory factory :
-	// ExtensionList.lookup(FileCallableWrapperFactory.class)) {
-	// wrapper = factory.wrap(wrapper);
-	// }
-	// return channel.call(wrapper);
-	// } catch (TunneledInterruptedException e) {
-	// throw (InterruptedException)new
-	// InterruptedException(e.getMessage()).initCause(e);
-	// } catch (AbortException e) {
-	// throw e; // pass through so that the caller can catch it as
-	// AbortException
-	// } catch (IOException e) {
-	// // wrap it into a new IOException so that we get the caller's stack trace
-	// as well.
-	// throw new IOException("remote file operation failed: " + remote + " at "
-	// + channel + ": " + e, e);
-	// }
-	// } else {
-	// // the file is on the local machine.
-	// return callable.invoke(new File(remote), localChannel);
-	// }
-	// }
-	//
-	// 
+}


### PR DESCRIPTION
The goal is to extend this plugin with a standalone tool installer for RAR-files.
Currently the installer is visible in the Global Tool Configuration view in Jenkins, but the extraction process is not fully implemented yet. At the moment, however, if anything from JUnrar is initialized the installer disappears from the configuration view (hence the large portion of commented code in the extraction method (Lines 274-325)).
Also getting a huge amount of warnings when compiling with Maven.
Stack trace when using "mvn package": [Stack trace output.txt](https://github.com/synopsys-arc-oss/extra-tool-installers-plugin/files/306861/Stack.trace.output.txt)

Not sure what the problem is and what to do next. All feedback is welcome.
